### PR TITLE
Update x_1.xml

### DIFF
--- a/app/src/main/res/layout/x_1.xml
+++ b/app/src/main/res/layout/x_1.xml
@@ -1,20 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/x_1"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@drawable/x_1"
+    android:background="#f9f9f9"
     tools:context=".x_1Activity"
     android:orientation="vertical"
     android:weightSum="1"
     tools:ignore="ExtraText">
 
-    <View
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_weight="0.7" />
+    <ImageView
+        android:id="@+id/imageView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:adjustViewBounds="true"
+        android:src="@drawable/x_1"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+    </ImageView>
+    <androidx.constraintlayout.widget.Guideline
+        app:layout_constraintGuide_percent="0.5"
+        android:id="@+id/guidelinetop"
+        android:orientation="horizontal"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+    </androidx.constraintlayout.widget.Guideline>
 
     <Button
         android:id="@+id/button_login"
@@ -27,20 +42,37 @@
         android:text="로그인"
         android:textColor="#F9F9F9"
         android:textSize="18sp"
-        app:backgroundTint="#6A6B8C" />
+        app:backgroundTint="#6A6B8C"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/button_sign"
+        app:layout_constraintTop_toTopOf="@id/guidelinetop"
+        />
 
     <Button
         android:id="@+id/button_sign"
         android:layout_width="match_parent"
         android:layout_height="60dp"
         android:layout_marginHorizontal="20dp"
-        android:layout_marginTop="20dp"
+        android:layout_marginStart="16dp"
         android:background="@drawable/button_round_sign_up"
         android:backgroundTint="#F9F9F9"
         android:text="회원가입"
         android:textColor="#6A6B8C"
         android:textSize="18dp"
-        app:backgroundTint="#F9F9F9" />
+        app:backgroundTint="#F9F9F9"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/button_login"
+        app:layout_constraintBottom_toTopOf="@id/guidelinebottom"
+        app:layout_constraintVertical_bias="0.5"
+         />
+    <androidx.constraintlayout.widget.Guideline
+        app:layout_constraintGuide_percent="0.8"
+        android:id="@+id/guidelinebottom"
+        android:orientation="horizontal"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+    </androidx.constraintlayout.widget.Guideline>
 
-
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
1. 이미지 비율 이슈 해결
일단 초기화면인 x_1.xml에 사진 비율에 관한 이슈를 수정했습니다 
Linearlayout에서 반응형 화면을 만들 수 있는 ConstraintLayout으로 레이아웃을 변경했습니다(id는 모두 동일합니다)

Layout을 변경하면서 비율은 android:adjustViewBounds="true”로 원본 사진과 일치하는 비율로 유지했습니다 (글씨가 눌리는 일을 방지했습니다)

Constraint layout의 widget인 guideline을 이용해서 전체 화면의 50%부분에 guideline 하나, 80% 부분에 guideline을 하나 설정했습니다 
(비율을 수정하셔서 버튼을 움직이시면 됩니다)

이 사이에 동일한 비율로 버튼들이 존재합니다
<img width="1440" alt="스크린샷 2021-03-03 오후 4 11 58" src="https://user-images.githubusercontent.com/45231740/109770692-393cc580-7c3f-11eb-993a-12138c1fc464.png">
<img width="1440" alt="스크린샷 2021-03-03 오후 4 12 15" src="https://user-images.githubusercontent.com/45231740/109770702-3d68e300-7c3f-11eb-966a-ada66bc868b1.png">
<img width="1440" alt="스크린샷 2021-03-03 오후 4 24 31" src="https://user-images.githubusercontent.com/45231740/109770703-3e017980-7c3f-11eb-883c-888a247249b5.png">
![Screenshot_1614756327](https://user-images.githubusercontent.com/45231740/109770710-3f32a680-7c3f-11eb-8ec4-b6dcefcda499.png)
![Screenshot_1614756324](https://user-images.githubusercontent.com/45231740/109770712-3f32a680-7c3f-11eb-99b7-6cccdb0ae521.png)
